### PR TITLE
Change input data address

### DIFF
--- a/DNN.ipynb
+++ b/DNN.ipynb
@@ -137,8 +137,8 @@
       "source": [
         "if first_run:\r\n",
         "  !rm *.root*\r\n",
-        "  !wget http://opendata.cern.ch/eos/opendata/atlas/OutreachDatasets/2020-01-22/1largeRjet1lep/MC/mc_387163.TT_directTT_600_1.1largeRjet1lep.root\r\n",
-        "  !wget http://opendata.cern.ch/eos/opendata/atlas/OutreachDatasets/2020-01-22/1largeRjet1lep/MC/mc_410000.ttbar_lep.1largeRjet1lep.root\r\n",
+        "  !wget https://atlas-opendata.web.cern.ch/atlas-opendata/samples/2020/1largeRjet1lep/MC/mc_387163.TT_directTT_600_1.1largeRjet1lep.root\r\n",
+        "  !wget https://atlas-opendata.web.cern.ch/atlas-opendata/samples/2020/1largeRjet1lep/MC/mc_410000.ttbar_lep.1largeRjet1lep.root\r\n",
         "  !ls"
       ],
       "execution_count": null,


### PR DESCRIPTION
The http://opendata.cern.ch address you were using seems to have gone down at some point today. I've changed to a different address, which is https, so better anyway.