### PR TITLE
Fix google colab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 
 # ATLAS_UK_NN_TUTORIAL
 ATLAS UK ML tutorial for 2021 ATLAS UK meeting
-Notebook in colab [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)]([![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb))
+Notebook in colab [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1az1juZ2sONpuzDqM5gEAwNpPRFz6nTpp?usp=sharing)


### PR DESCRIPTION
Google colab link in README now takes user straight to notebook in colab. 

Still need to update this to point to the latest notebook from GitHub (not sure yet how to do this)